### PR TITLE
Fix title wrapping

### DIFF
--- a/pages/[...name].js
+++ b/pages/[...name].js
@@ -10,20 +10,25 @@ import CopyLinkButton from '../components/CopyLinkButton'
 const title = (name) => {
 
   const wish = 'Happy Birthday ' + name + "!"
-  const letters = []
+  const base_letters = []
+  const name_letters = []
 
   for (let i = 0; i < wish.length; i++) {
-    const letter = wish.charAt(i)
-
-    if (i > 14)
-      letters.push(<span key={i} style={{ "--i": i + 1 }} className={styles.span}>{letter}</span>)
-    else
-      letters.push(<span key={i} style={{ "--i": i + 1 }}>{letter}</span>)
+    
+    if (i < 15) {
+      const letter = wish.charAt(i)
+      base_letters.push(<span key={i} style={{ "--i": i + 1 }}>{letter}</span>)
+    }
+    else {
+      const letter = wish.charAt(i)
+      name_letters.push(<span key={i} style={{ "--i": i + 1 }} className={styles.span}>{letter}</span>)
+    }
   }
 
   return (
     <h1 className={styles.title} style={{ "--wish-length": wish.length }}>
-      {letters.map((letter) => letter)}
+      <div>{base_letters.map((letter) => letter)}</div>
+      <div>{name_letters.map((letter) => letter)}</div>
     </h1>
   )
 }
@@ -31,8 +36,8 @@ const title = (name) => {
 const Wish = ({ history }) => {
 
   const router = useRouter();
-  const { name } = router.query; // gets both name & color id in form of array [name,colorId]
-  const color = name ? name[1] : 0;//extracting colorId from name
+  const { name } = router.query;    // gets both name & color id in form of array [name,colorId]
+  const color = name ? name[1] : 0; //extracting colorId from name
 
   const { setTheme } = useTheme();
 

--- a/styles/Name.module.css
+++ b/styles/Name.module.css
@@ -52,11 +52,18 @@
   line-height: 1.15;
   font-size: 3rem;
   text-align: center;
-  display: block;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  row-gap: 0.3em;
 }
 
 /* Added animation on the title */
-.title span {
+.title div {
+  flex-shrink: 0;
+}
+
+.title div span {
   display: inline-block;
   white-space: pre;
   animation: wavyText 1.5s ease-in-out 2s infinite;


### PR DESCRIPTION
I've added a flex container for each word. It should look better on small screen size (Minimum around 400px).
It should break by word instead of individual letter. Also, `row-gap` should prevent animating text from overlapping.