### PR TITLE
Add optional image URL support to birthday wishes

### DIFF
--- a/pages/[...name].js
+++ b/pages/[...name].js
@@ -10,166 +10,146 @@ import FileSaver from "file-saver";
 import { Button, CopyLinkButton } from "../components";
 
 const Wish = ({ history }) => {
-	const router = useRouter();
-	const { name } = router.query; // gets both name & color id in form of array [name,colorId]
-	const color = name ? name[1] : 0; //extracting colorId from name
-	const [downloading, setDownloading] = useState(false);
-	const [downloadedOnce, setDownloadedOnce] = useState(false);
-	const audioRef = useRef();
+  const router = useRouter();
+  const { name } = router.query;
+  const color = name ? name[1] : 0;
+  const imageUrl = router.query.img; //new
 
-	const { setTheme } = useTheme();
+  const [downloading, setDownloading] = useState(false);
+  const [downloadedOnce, setDownloadedOnce] = useState(false);
+  const audioRef = useRef();
 
-	useEffect(() => {
-		// Theme Change
-		setTheme(color);
+  const { setTheme } = useTheme();
 
-		if (downloading === false) {
-			// Confetti
-			const confettiSettings = {
-				target: "canvas",
-				start_from_edge: true,
-			};
-			const confetti = new ConfettiGenerator(confettiSettings);
-			confetti.render();
-			audioRef.current.play();
-		}
-	}, [color, downloading]);
+  useEffect(() => {
+    setTheme(color);
 
-	useEffect(() => {
-		if (downloading === true && downloadedOnce === false) {
-			downloadImage();
-		}
-	}, [downloading, downloadedOnce]);
+    if (!downloading) {
+      const confetti = new ConfettiGenerator({
+        target: "canvas",
+        start_from_edge: true,
+      });
+      confetti.render();
+      audioRef.current.play();
+    }
+  }, [color, downloading]);
 
-	// function for randomly picking the message from messages array
-	const randomNumber = (min, max) => {
-		return Math.floor(Math.random() * (max - min)) + min;
-	};
+  useEffect(() => {
+    if (downloading && !downloadedOnce) downloadImage();
+  }, [downloading, downloadedOnce]);
 
-	const downloadImage = () => {
-		if (downloadedOnce === true) return;
+  const randomNumber = (min, max) =>
+    Math.floor(Math.random() * (max - min)) + min;
 
-		const node = document.getElementById("image");
+  const downloadImage = () => {
+    if (downloadedOnce) return;
 
-		if (node) {
-			setDownloadedOnce(true);
+    const node = document.getElementById("image");
+    if (!node) return;
 
-			htmlToImage.toPng(node).then((blob) => {
-				FileSaver.saveAs(blob, "birthday-wish.png");
-				setDownloading(false);
-			});
-		}
-	};
+    setDownloadedOnce(true);
+    htmlToImage.toPng(node).then((blob) => {
+      FileSaver.saveAs(blob, "birthday-wish.png");
+      setDownloading(false);
+    });
+  };
 
-	const title = (name) => {
-		const wish = "Happy Birthday " + name + "!";
-		const base_letters = [];
-		const name_letters = [];
+  const title = (name) => {
+    const wish = "Happy Birthday " + name + "!";
+    const base_letters = [];
+    const name_letters = [];
 
-		for (let i = 0; i < wish.length; i++) {
-			if (i < 15) {
-				const letter = wish.charAt(i);
-				base_letters.push(
-					<span key={i} style={{ "--i": i + 1 }}>
-						{letter}
-					</span>
-				);
-			} else {
-				const letter = wish.charAt(i);
-				name_letters.push(
-					<span key={i} style={{ "--i": i + 1 }} className={styles.span}>
-						{letter}
-					</span>
-				);
-			}
-		}
+    for (let i = 0; i < wish.length; i++) {
+      const letter = wish.charAt(i);
+      const span = (
+        <span key={i} style={{ "--i": i + 1 }}>
+          {letter}
+        </span>
+      );
+      i < 15 ? base_letters.push(span) : name_letters.push(span);
+    }
 
-		return (
-			<>
-				{downloading ? (
-					<h1
-						className={styles.titleImg}
-						style={{ "--wish-length": wish.length }}
-					>
-						<div>{base_letters.map((letter) => letter)}</div>
-						<div>{name_letters.map((letter) => letter)}</div>
-					</h1>
-				) : (
-					<h1 className={styles.title} style={{ "--wish-length": wish.length }}>
-						<div>{base_letters.map((letter) => letter)}</div>
-						<div>{name_letters.map((letter) => letter)}</div>
-					</h1>
-				)}
-			</>
-		);
-	};
+    return (
+      <h1
+        className={downloading ? styles.titleImg : styles.title}
+        style={{ "--wish-length": wish.length }}
+      >
+        <div>{base_letters}</div>
+        <div className={styles.span}>{name_letters}</div>
+      </h1>
+    );
+  };
 
-	if (downloading) {
-		return (
-			<div className={styles.containerImg} id="image" onClick={downloadImage}>
-				{downloadImage()}
-				<main className={styles.image}>
-					<div>
-						<div className={styles.main}>{title(name && name[0])}</div>
+  if (downloading) {
+    return (
+      <div className={styles.containerImg} id="image">
+        <main className={styles.image}>
+          <div>
+            {imageUrl && (
+              <img
+                src={imageUrl}
+                alt="Birthday"
+                className={styles.birthdayImage}
+              />
+            )}
 
-						<div style={{ height: 40 }} />
+            <div className={styles.main}>{title(name && name[0])}</div>
+            <div style={{ height: 40 }} />
+            <p className={styles.descImg}>
+              {messages[randomNumber(0, messages.length)].value}
+            </p>
+          </div>
+        </main>
+      </div>
+    );
+  }
 
-						<p className={styles.descImg}>
-							{messages[randomNumber(0, messages.length)].value}
-						</p>
-					</div>
-				</main>
-			</div>
-		);
-	}
+  return (
+    <div className={styles.container}>
+      <Head>
+        <title>Happy Birthday {name && name[0]}</title>
+        <meta name="description" content="A surprise birthday wish!" />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
 
-	return (
-		<div className={styles.container}>
-			<Head>
-				<title>Happy Birthday {name && name[0]}</title>
-				<meta
-					name="description"
-					content={`A surprise birthday wish!`}
-				/>
-				<link rel="icon" href="/favicon.ico" />
-			</Head>
+      <canvas className={styles.canvas} id="canvas"></canvas>
 
-			<canvas className={styles.canvas} id="canvas"></canvas>
+      <main className={styles.animate}>
+        <div>
+          {imageUrl && (
+            <img
+              src={imageUrl}
+              alt="Birthday"
+              className={styles.birthdayImage}
+            />
+          )}
 
-			<main className={styles.animate}>
-				<div>
-					<div className={styles.main}>{title(name && name[0])}</div>
-					<p className={styles.desc}>
-						{messages[randomNumber(0, messages.length)].value}
-					</p>
-				</div>
+          <div className={styles.main}>{title(name && name[0])}</div>
+          <p className={styles.desc}>
+            {messages[randomNumber(0, messages.length)].value}
+          </p>
+        </div>
 
-				<div className={styles.buttonContainer}>
-					{history[0] == "/" ? <CopyLinkButton /> : ""}
+        <div className={styles.buttonContainer}>
+          {history[0] === "/" && <CopyLinkButton />}
+          {history[0] === "/" && (
+            <Button
+              onClick={() => {
+                setDownloadedOnce(false);
+                setDownloading(true);
+              }}
+              text="Download as Image"
+            />
+          )}
+          <Button onClick={() => router.push("/")} text="← Create a wish" />
+        </div>
+      </main>
 
-					{history[0] == "/" ? (
-						<Button
-							onClick={() => {
-								setDownloadedOnce(false);
-								setDownloading(true);
-							}}
-							text="Download as Image"
-						/>
-					) : (
-						""
-					)}
-
-					<Button
-						onClick={() => router.push("/")}
-						text="&larr; Create a wish"
-					/>
-				</div>
-			</main>
-			<audio ref={audioRef} id="player" autoPlay>
-				<source src="media/hbd.mp3" />
-			</audio>
-		</div>
-	);
+      <audio ref={audioRef} autoPlay>
+        <source src="media/hbd.mp3" />
+      </audio>
+    </div>
+  );
 };
 
 export default Wish;

--- a/pages/index.js
+++ b/pages/index.js
@@ -8,6 +8,7 @@ import { Button } from "../components";
 export default function Home() {
   const { themes, setTheme, currentTheme } = useTheme();
   const [value, setValue] = useState("");
+  const [imageUrl, setImageUrl] = useState(""); //new
 
   const handleInput = (e) => {
     e.preventDefault();
@@ -17,16 +18,23 @@ export default function Home() {
       alert("Please enter a name!");
       return;
     }
-    if (id == 0) Router.push(value);
-    // If the theme is default blue then push to '/{name}'
-    else Router.push(`/${value}/${id}`); // If the theme is not default then will push to '/{name}?color={id}
+
+    const imgParam = imageUrl
+      ? `?img=${encodeURIComponent(imageUrl)}`
+      : "";
+
+    if (id == 0) Router.push(`${value}${imgParam}`);
+    else Router.push(`/${value}/${id}${imgParam}`);
   };
 
   return (
     <div className={styles.container}>
       <Head>
         <title>Create a Birthday Wish</title>
-        <meta name="description" content="An app to generate birthday wishes :)" />
+        <meta
+          name="description"
+          content="An app to generate birthday wishes :)"
+        />
         <link rel="icon" href="/favicon.ico" />
       </Head>
 
@@ -36,8 +44,8 @@ export default function Home() {
             Create a <span className={styles.span}>Birthday</span> Wish
           </h1>
         </div>
-        {/* Theme Color  */}
 
+        {/* Theme Color */}
         <div className={styles.themeWrapper}>
           <form
             className={styles.theme}
@@ -68,8 +76,32 @@ export default function Home() {
               value={value}
               onChange={(e) => setValue(e.target.value)}
             />
+
+            {/* NEW IMAGE URL INPUT */}
+            <input
+              className={styles.input}
+              type="url"
+              placeholder="Image URL (optional)"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+            />
+
             <Button className={styles.button} type="submit" text="Go!" />
           </form>
+
+          {/* helper link */}
+          <p className={styles.desc} style={{ fontSize: "14px" }}>
+            Don’t have an image link?{" "}
+            <a
+              className={styles.span}
+              href="https://postimages.org/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Upload here
+            </a>
+          </p>
+
           <p className={styles.desc}>
             Crafted by{" "}
             <a

--- a/pages/index.js
+++ b/pages/index.js
@@ -94,11 +94,11 @@ export default function Home() {
             Don’t have an image link?{" "}
             <a
               className={styles.span}
-              href="https://postimages.org/"
+              href="https://www.image2url.com/"
               target="_blank"
               rel="noreferrer"
             >
-              Upload here
+              Upload here for link
             </a>
           </p>
 

--- a/styles/Name.module.css
+++ b/styles/Name.module.css
@@ -170,3 +170,12 @@
   flex-direction: column;
   row-gap: 1em;
 }
+
+/* ---------------------------- */
+
+.birthdayImage {
+  max-width: 200px;
+  border-radius: 50%;
+  display: block;
+  margin: 0 auto 20px;
+}


### PR DESCRIPTION
## What’s new?
This PR adds an **optional image URL field** while creating a birthday wish.
If provided, the image is displayed on the wish page above the birthday message.

## Why this change?
This allows users to personalize birthday wishes further (e.g. adding a photo of the birthday person),
while keeping the app **lightweight and serverless**.

## Implementation details
- Images are loaded from **public image URLs only**
- No files are uploaded or stored
- Feature is completely **optional**
- Existing links and behavior remain unchanged

## Tested locally
- Name-only wish works as before
- Image + name renders correctly
- Shared links retain the image
- Download as image includes the photo

## 📸 Screenshots

<img width="735" height="549" alt="image" src="https://github.com/user-attachments/assets/e7f2ccd8-a2ad-4b56-a757-b43590ca7db3" />
